### PR TITLE
Don't quote extra args

### DIFF
--- a/conf/backup
+++ b/conf/backup
@@ -71,20 +71,20 @@ if [[ ${#apps[@]} -eq 0 && ${#system[@]} -eq 0 ]]; then
     exit 0
 fi
 # Define apps option
-apps_option=""
+apps_option=()
 if [[ ${#apps[@]} -ne 0 ]]; then
-    apps_option=" --apps ${apps[*]}"
+    apps_option=("--apps" "${apps[@]}")
 fi
 
 # Define system option
-option_system=""
+system_option=()
 if [[ ${#system[@]} -ne 0 ]]; then
-    option_system=" --system ${system[*]}"
+    system_option=("--system" "${system[@]}")
 fi
 
 current_date=$(date +"%Y%m%d-%H%M%S")
 if $is_verbose; then
-    log "yunohost backup create --name '${current_date}___APP__' --method '__APP___app' $option_system $apps_option"
+    log "yunohost backup create --name '${current_date}___APP__' --method '__APP___app' ${system_option[*]} ${apps_option[*]}"
 fi
 
-execute_cmd sudo yunohost backup create --name "${current_date}___APP__" --method "__APP___app" $option_system $apps_option || set_error
+execute_cmd sudo yunohost backup create --name "${current_date}___APP__" --method "__APP___app" "${system_option[@]}" "${apps_option[@]}" || set_error

--- a/conf/backup
+++ b/conf/backup
@@ -87,4 +87,4 @@ if $is_verbose; then
     log "yunohost backup create --name '${current_date}___APP__' --method '__APP___app' $option_system $apps_option"
 fi
 
-execute_cmd sudo yunohost backup create --name "${current_date}___APP__" --method "__APP___app" "$option_system" "$apps_option" || set_error
+execute_cmd sudo yunohost backup create --name "${current_date}___APP__" --method "__APP___app" $option_system $apps_option || set_error


### PR DESCRIPTION
As reported [on the forums](https://forum.yunohost.org/t/yuno-archive-doesnt-respect-main-content-save-data-multimedia/40995) the app unconditionally backs up everything.

Examining the [log](https://paste.yunohost.org/raw/inuwoxacap) yields `--system` and `--apps` are treated as backup methods, not params.

Unquote them.